### PR TITLE
feat: docker-compose에 mariadb 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ sw.*
 
 # Vim swap files
 *.swp
+
+# Mysql Root Password
+mysql-root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,27 @@
 version: '3'
 
 services:
+  db:
+    image: mariadb:10.4
+    restart: always
+    container_name: swdb_db
+    ports:
+      - 3306:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD_FILE=./mysql-root
+      - TZ=Asia/Seoul
+    volumes:
+      - ./mysql-root:/mysql-root:ro
+
   swdb:
     build:
       context: .
       dockerfile: ./Dockerfile
+    restart: always
+    container_name: swdb_web
+    depends_on:
+      - db
     ports:
-      - "80:80"
+      - 80:80
     command:
       - bash Run


### PR DESCRIPTION
프로젝트 제일 상단에 `mysql-root` 파일을 만들어야 db가 동작하며, 이때 `mysql-root`의 내용은 mariadb의 root password가 됩니다.